### PR TITLE
Isolate test database and enforce state cleanup for every tests

### DIFF
--- a/graph/schema.resolvers_test.go
+++ b/graph/schema.resolvers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -11,17 +12,24 @@ import (
 	_ "github.com/lib/pq"
 )
 
-// --- CONFIGURATION ---
-const connStr = "user=user password=password dbname=btp_tokens sslmode=disable host=localhost port=5432"
-
-// --- HELPER FUNCTIONS ---
-
 // setupTestDB connects to the database or fails the test immediately
 func setupTestDB(t *testing.T) *sql.DB {
-	db, err := sql.Open("postgres", connStr)
-	if err != nil {
-		t.Fatalf("Failed to connect to DB: %v", err)
+	testDB := "postgres://user:password@localhost:5432/btp_test?sslmode=disable"
+	if envDSN := os.Getenv("TEST_DATABASE_URL"); envDSN != "" {
+		testDB = envDSN
 	}
+
+	// Open connection
+	db, err := sql.Open("postgres", testDB)
+	if err != nil {
+		t.Fatalf("Failed to connect to  test DB: %v", err)
+	}
+
+	// Check connection
+	if err := db.Ping(); err != nil {
+		t.Fatalf("Failed to ping TEST database. Did you run 'docker-compose up'? Error: %v", err)
+	}
+
 	return db
 }
 

--- a/graph/schema.resolvers_test.go
+++ b/graph/schema.resolvers_test.go
@@ -30,7 +30,16 @@ func setupTestDB(t *testing.T) *sql.DB {
 		t.Fatalf("Failed to ping TEST database. Did you run 'docker-compose up'? Error: %v", err)
 	}
 
+	cleanTestDB(t, db) // Clean db before return
 	return db
+}
+
+// cleanTestDB removes all data from tables to ensure test isolation
+func cleanTestDB(t *testing.T, db *sql.DB) {
+	_, err := db.Exec("TRUNCATE TABLE wallets")
+	if err != nil {
+		t.Fatalf("Failed to clean database: %v", err)
+	}
 }
 
 // resetWallet inserts or updates a wallet to a specific balance for testing

--- a/graph/schema.resolvers_test.go
+++ b/graph/schema.resolvers_test.go
@@ -179,7 +179,7 @@ func TestConcurrent_MixedThreadsScenario(t *testing.T) {
 			t.Errorf(" - Mixed Threads Scenario Failed. Invalid balance: %d", finalBalance)
 		}
 	}
-	fmt.Printf(" + Mixed Threads Scenario Passed. All %d iterations gave outcome 0, 7 or 4", iterations)
+	fmt.Printf(" + Mixed Threads Scenario Passed. All %d iterations gave outcome 0, 7 or 4\n", iterations)
 }
 
 // 4. Security Test: Negative Amount

--- a/init.sql
+++ b/init.sql
@@ -2,7 +2,7 @@
 --"Initially, there is only one wallet (...) holding 1,000,000 BTP tokens".
 -- Init wallets table
 CREATE TABLE IF NOT EXISTS wallets (
-                                       address VARCHAR(255) PRIMARY KEY,
+    address VARCHAR(255) PRIMARY KEY,
     -- No requirements about balance size.
     -- If preferable INTEGER may be changed for BIGINT
     balance INTEGER NOT NULL CHECK (balance >= 0)
@@ -13,3 +13,13 @@ CREATE TABLE IF NOT EXISTS wallets (
 INSERT INTO wallets (address, balance)
 VALUES ('0x0000000000000000000000000000000000000000', 1000000)
     ON CONFLICT (address) DO NOTHING;
+
+-- Database for tests --
+CREATE DATABASE btp_test;
+\c btp_test;
+
+-- Tworzymy tę samą tabelę w bazie testowej
+CREATE TABLE IF NOT EXISTS wallets (
+    address VARCHAR(255) PRIMARY KEY,
+    balance INTEGER NOT NULL CHECK (balance >= 0)
+);


### PR DESCRIPTION
This pull request changes the testing setup to be safer and more reliable. A separate database just for tests (btp_test) has been added and made sure that the database is empty before every test runs.

1. Modified init.sql to create a second database named btp_test. Now, running tests acts on btp_test and will not touch or delete data in the main btp_tokens database.
2. Added support for TEST_DATABASE_URL environment variable to support both local (localhost) and Docker-based (CI/CD) execution.
3. Implemented cleanTestDB helper function using SQL TRUNCATE. Updated setupTestDB to execute cleanup before every test. This guarantees a pristine environment for each test case, eliminating dependencies on previous test outcomes.

Resolves: #21 #22 